### PR TITLE
MULE-11577: Fix: Re-creating queues and exchanges while re-connecting…

### DIFF
--- a/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/client/AmqpDeclarer.java
+++ b/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/client/AmqpDeclarer.java
@@ -196,4 +196,8 @@ public class AmqpDeclarer
         return exchangeName;
     }
 
+    public AmqpEndpointUtil getEndpointUtil()
+    {
+        return endpointUtil;
+    }
 }

--- a/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/endpoint/receiver/MultiChannelMessageReceiver.java
+++ b/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/endpoint/receiver/MultiChannelMessageReceiver.java
@@ -106,6 +106,12 @@ public class MultiChannelMessageReceiver extends AbstractMessageReceiver
             queueName = declarator.declareEndpoint(channel, endpoint, true);
             declared = true;
         }
+        else
+        {
+            final String exchangeName = declarator.declareExchange(channel, endpoint, true);
+            String routingKey = declarator.getEndpointUtil().getRoutingKey(endpoint);
+            declarator.declareBinding(channel, endpoint, exchangeName, routingKey, queueName);
+        }
     }
 
 


### PR DESCRIPTION
A time ago, a refactor was done in the mule-transport-amqp project. After that, the bindings only are created in the first connection, because of a flag in a if condition.
Loss of bindings should be considered as a posible scenario.
_**Test Case will be added in a different PR.**_