### PR TITLE
AMQP-69: AMQP Connector is not supporting dynamic routing keys.

### DIFF
--- a/mule-transport-amqp/src/it/java/org/mule/transport/amqp/DynamicRoutingKeyItCase.java
+++ b/mule-transport-amqp/src/it/java/org/mule/transport/amqp/DynamicRoutingKeyItCase.java
@@ -6,8 +6,9 @@
  */
 package org.mule.transport.amqp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
 import org.mule.api.MuleMessage;
 import org.mule.transport.amqp.harness.AbstractItCase;
 
@@ -27,8 +28,8 @@ public class DynamicRoutingKeyItCase extends AbstractItCase
     {
         runFlow("senderFlow");
         MuleMessage result = muleContext.getClient().request("vm://result", 5000);
-        assertNotNull(result);
-        assertEquals(result.getPayloadAsString(), "testedDynamicRoutingKey");
+        assertThat(result, is(notNullValue()));
+        assertThat(result.getPayloadAsString(), is("testedDynamicRoutingKey"));
     }
 
 }

--- a/mule-transport-amqp/src/it/java/org/mule/transport/amqp/DynamicRoutingKeyItCase.java
+++ b/mule-transport-amqp/src/it/java/org/mule/transport/amqp/DynamicRoutingKeyItCase.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  https://github.com/mulesoft/mule-transport-amqp
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.amqp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.mule.api.MuleMessage;
+import org.mule.transport.amqp.harness.AbstractItCase;
+
+import org.junit.Test;
+
+public class DynamicRoutingKeyItCase extends AbstractItCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "dynamic-routing-key-config.xml";
+    }
+
+    @Test
+    public void testDynamicRoutingKey() throws Exception
+    {
+        runFlow("senderFlow");
+        MuleMessage result = muleContext.getClient().request("vm://result", 5000);
+        assertNotNull(result);
+        assertEquals(result.getPayloadAsString(), "testedDynamicRoutingKey");
+    }
+
+}

--- a/mule-transport-amqp/src/it/resources/dynamic-routing-key-config.xml
+++ b/mule-transport-amqp/src/it/resources/dynamic-routing-key-config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:amqp="http://www.mulesoft.org/schema/mule/amqp" xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+             http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+       http://www.mulesoft.org/schema/mule/amqp http://www.mulesoft.org/schema/mule/amqp/current/mule-amqp.xsd
+       ">
+
+    <amqp:connector name="amqpConnector" 
+        virtualHost="${amqpVirtualHost}"
+        username="${amqpUserName}"
+        password="${amqpPassword}"
+        host="${amqpHost}"
+        port="${amqpPort}" />
+
+
+    <flow name="senderFlow">
+        <set-variable variableName="testRoutingKey" value="testRoutingKeyValue"/>
+        <amqp:outbound-endpoint queueName="testQueue" routingKey="#[testRoutingKey]"
+                                exchangeName="testExchange"
+                                exchangeType="topic"
+                                connector-ref="amqpConnector" exchange-pattern="request-response"/>
+    </flow>
+
+    <flow name="receiverFlow">
+        <amqp:inbound-endpoint exchangeName="testExchange"
+                               exchangeType="topic"
+                               queueDurable="true"
+                               routingKey="testRoutingKeyValue"
+                               queueName="testQueue2"  connector-ref="amqpConnector"
+                               />
+        <set-payload value="testedDynamicRoutingKey"/>
+        <vm:outbound-endpoint path="result"/>
+    </flow>
+</mule>

--- a/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/client/AmqpDeclarer.java
+++ b/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/client/AmqpDeclarer.java
@@ -9,6 +9,8 @@ package org.mule.transport.amqp.internal.client;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import org.apache.commons.lang.BooleanUtils;
+
+import org.mule.api.endpoint.EndpointURI;
 import org.mule.api.endpoint.ImmutableEndpoint;
 import org.mule.transport.amqp.internal.connector.AmqpConnector;
 import org.mule.transport.amqp.internal.endpoint.AmqpEndpointUtil;
@@ -17,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 
 public class AmqpDeclarer
@@ -50,20 +51,24 @@ public class AmqpDeclarer
                                   final String routingKey) throws IOException
     {
         final String queueName = endpointUtil.getQueueName(endpoint.getAddress());
+        final EndpointURI uri = endpoint.getEndpointURI();
+        final boolean isDynamicBinding = endpointUtil.isDynamicRoutingKey(routingKey, endpoint);
 
         // no queue name -> create a private one on the server
         if (StringUtils.isBlank(queueName))
         {
             final String privateQueueName = declareTemporaryQueue(channel);
-            declareBinding(channel, endpoint, exchangeName, routingKey, privateQueueName);
+
+            if(!isDynamicBinding)
+            {
+                declareBinding(channel, exchangeName, routingKey, privateQueueName);
+            }
+
             return privateQueueName;
         }
 
-        if (logger.isDebugEnabled())
-        {
-            logger.debug("Declaring endpoint with URI: " + endpoint.getEndpointURI() + " with exchange: " + exchangeName + " rountingKey: " +
-                routingKey + " queueName: " + queueName);
-        }
+        logDeclaredEndpoint(uri, exchangeName, routingKey, queueName, isDynamicBinding);
+
 
         // queue name -> either create or ensure the queue exists
         if (endpoint.getProperties().containsKey(AmqpConnector.ENDPOINT_PROPERTY_QUEUE_DURABLE)
@@ -78,8 +83,10 @@ public class AmqpDeclarer
             final Map<String, Object> arguments = endpointUtil.getArguments(endpoint, AmqpConnector.ENDPOINT_QUEUE_PREFIX);
 
             declareQueueActively(channel, queueName, queueDurable, queueExclusive, queueAutoDelete, arguments);
-
-            declareBinding(channel, endpoint, exchangeName, routingKey, queueName);
+            if(!isDynamicBinding)
+            {
+                declareBinding(channel, exchangeName, routingKey, queueName);
+            }
         }
         else if (!activeDeclarationsOnly)
         {
@@ -87,11 +94,7 @@ public class AmqpDeclarer
             declareQueuePassively(channel, queueName);
         }
 
-        if (logger.isDebugEnabled())
-        {
-            logger.debug("Declared endpoint with URI: " + endpoint.getEndpointURI() + " with exchange: " + exchangeName + " rountingKey: " +
-                    routingKey + " queueName: " + queueName);
-        }
+        logDeclaredEndpoint(uri, exchangeName, routingKey, queueName, isDynamicBinding);
 
         return queueName;
     }
@@ -126,7 +129,6 @@ public class AmqpDeclarer
     }
 
     public void declareBinding(final Channel channel,
-                                final ImmutableEndpoint endpoint,
                                 final String exchangeName,
                                 final String routingKey,
                                 final String queueName) throws IOException
@@ -199,5 +201,22 @@ public class AmqpDeclarer
     public AmqpEndpointUtil getEndpointUtil()
     {
         return endpointUtil;
+    }
+
+    private void logDeclaredEndpoint (EndpointURI uri, String exchangeName, String routingKey, String queueName, boolean isDynamicBinding)
+    {
+        if (logger.isDebugEnabled())
+        {
+            if(isDynamicBinding)
+            {
+                logger.debug("Declaring endpoint with URI: " + uri + " with exchange: " + exchangeName + " queueName: " + queueName
+                    +". As routing key has a dynamic value, initial binding is ignored.");
+            }
+            else
+            {
+                logger.debug("Declaring endpoint with URI: " + uri + " with exchange: " + exchangeName + " rountingKey: " +
+                             routingKey + " queueName: " + queueName);
+            }
+        }
     }
 }

--- a/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/endpoint/AmqpEndpointUtil.java
+++ b/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/endpoint/AmqpEndpointUtil.java
@@ -90,6 +90,12 @@ public class AmqpEndpointUtil
         return routingKey;
     }
 
+    public boolean isDynamicRoutingKey(final String routingKey, final ImmutableEndpoint endpoint)
+    {
+        ExpressionManager expressionManager = endpoint.getMuleContext().getExpressionManager();
+        return expressionManager.isExpression(routingKey);
+    }
+
     private String getDynamicRoutingKey(final ImmutableEndpoint endpoint, final MuleEvent muleEvent)
     {
         final String eventRoutingKey = muleEvent.getMessage().getOutboundProperty(AmqpConnector.MESSAGE_PROPERTY_ROUTING_KEY,

--- a/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/endpoint/dispatcher/Dispatcher.java
+++ b/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/endpoint/dispatcher/Dispatcher.java
@@ -85,13 +85,12 @@ public class Dispatcher extends AbstractMessageDispatcher
         {
             boolean activeDeclarationsOnly = amqpConnector.isActiveDeclarationsOnly();
             final String exchangeName = declarator.declareExchange(channel, endpoint, activeDeclarationsOnly);
-            final String routingKey = endpointUtil.getRoutingKey(endpoint);
             if (StringUtils.isNotEmpty(endpointUtil.getQueueName(endpoint.getAddress()))
-                    || endpoint.getProperties().containsKey(ENDPOINT_PROPERTY_QUEUE_DURABLE)
-                    || endpoint.getProperties().containsKey(ENDPOINT_PROPERTY_QUEUE_AUTO_DELETE)
-                    || endpoint.getProperties().containsKey(ENDPOINT_PROPERTY_QUEUE_EXCLUSIVE))
+                || endpoint.getProperties().containsKey(ENDPOINT_PROPERTY_QUEUE_DURABLE)
+                || endpoint.getProperties().containsKey(ENDPOINT_PROPERTY_QUEUE_AUTO_DELETE)
+                || endpoint.getProperties().containsKey(ENDPOINT_PROPERTY_QUEUE_EXCLUSIVE))
             {
-                declarator.declareEndpoint(channel, endpoint, activeDeclarationsOnly, exchangeName, routingKey);
+                declarator.declareEndpoint(channel, endpoint, activeDeclarationsOnly, exchangeName);
             }
         }
         catch (IOException e)
@@ -155,7 +154,7 @@ public class Dispatcher extends AbstractMessageDispatcher
             logger.debug("Reopening unexpectedly closed channel");
             channel = amqpConnector.getChannelHandler().getOrCreateChannel(getEndpoint());
         }
-        
+
         // If a transaction resource channel is present use it, otherwise use the dispatcher's channel
         Channel eventChannel = amqpConnector.getChannelHandler().getOrDefaultChannel(endpoint, event.getMessage(), channel);
 
@@ -195,7 +194,19 @@ public class Dispatcher extends AbstractMessageDispatcher
         }
 
         final String eventExchange = endpointUtil.getExchangeName(endpoint, event);
-        final String eventRoutingKey = endpointUtil.getRoutingKey(endpoint, event);
+        String routingKey = endpointUtil.getRoutingKey(endpoint);
+        String eventRoutingKey = endpointUtil.getRoutingKey(endpoint, event);
+
+        String queueName = endpointUtil.getQueueName(endpoint.getAddress());
+
+        if(endpointUtil.isDynamicRoutingKey(routingKey, endpoint))
+        {
+            if(StringUtils.isNotEmpty(queueName))
+            {
+                declarator.declareBinding(eventChannel, eventExchange, eventRoutingKey, queueName);
+            }
+        }
+
         final long timeout = getTimeOutForEvent(event);
 
         AmqpMessage result;

--- a/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/endpoint/receiver/MultiChannelMessageReceiver.java
+++ b/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/endpoint/receiver/MultiChannelMessageReceiver.java
@@ -110,7 +110,7 @@ public class MultiChannelMessageReceiver extends AbstractMessageReceiver
         {
             final String exchangeName = declarator.declareExchange(channel, endpoint, true);
             String routingKey = declarator.getEndpointUtil().getRoutingKey(endpoint);
-            declarator.declareBinding(channel, endpoint, exchangeName, routingKey, queueName);
+            declarator.declareBinding(channel, exchangeName, routingKey, queueName);
         }
     }
 


### PR DESCRIPTION
AMQP endpoints binds queues to the exchanges using the routing keys only at initialization. 
However, when a routingKey is an expression, it is being used for binding without the necessary conversion.
This behavior causes that in flow executions, each message with a different (dynamic) routing key is being lost, since the queue not bound to the exchange with these routing key values.
