### PR TITLE
AMQP-70: activeDeclarationsOnly attribute is ignored when some attributes are defined

### DIFF
--- a/mule-transport-amqp/src/it/java/org/mule/transport/amqp/MessageDispatcherItCase.java
+++ b/mule-transport-amqp/src/it/java/org/mule/transport/amqp/MessageDispatcherItCase.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 public class MessageDispatcherItCase extends AbstractItCase
 {

--- a/mule-transport-amqp/src/it/resources/message-dispatcher-tests-config.xml
+++ b/mule-transport-amqp/src/it/resources/message-dispatcher-tests-config.xml
@@ -14,7 +14,9 @@
         username="${amqpUserName}"
         password="${amqpPassword}"
         host="${amqpHost}"
-        port="${amqpPort}" />
+        port="${amqpPort}"
+        activeDeclarationsOnly="true"
+    />
 
     <amqp:connector name="activeOnlyAmqpConnector" 
         virtualHost="${amqpVirtualHost}"

--- a/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/client/AmqpDeclarer.java
+++ b/mule-transport-amqp/src/main/java/org/mule/transport/amqp/internal/client/AmqpDeclarer.java
@@ -24,7 +24,7 @@ public class AmqpDeclarer
 {
     private static final Logger logger = LoggerFactory.getLogger(AmqpDeclarer.class);
 
-    protected AmqpEndpointUtil endpointUtil = new AmqpEndpointUtil();
+    protected AmqpEndpointUtil endpointUtil = createAmqpEndpointUtil();
 
     public String declareEndpoint(final Channel channel,
                                   final ImmutableEndpoint endpoint,
@@ -66,9 +66,9 @@ public class AmqpDeclarer
         }
 
         // queue name -> either create or ensure the queue exists
-        if (endpoint.getProperties().containsKey(AmqpConnector.ENDPOINT_PROPERTY_QUEUE_DURABLE)
+        if (activeDeclarationsOnly && (endpoint.getProperties().containsKey(AmqpConnector.ENDPOINT_PROPERTY_QUEUE_DURABLE)
                 || endpoint.getProperties().containsKey(AmqpConnector.ENDPOINT_PROPERTY_QUEUE_AUTO_DELETE)
-                || endpoint.getProperties().containsKey(AmqpConnector.ENDPOINT_PROPERTY_QUEUE_EXCLUSIVE))
+                || endpoint.getProperties().containsKey(AmqpConnector.ENDPOINT_PROPERTY_QUEUE_EXCLUSIVE)))
         {
             // any of the queue declaration parameter provided -> declare the queue
             final boolean queueDurable = BooleanUtils.toBoolean((String) endpoint.getProperty(AmqpConnector.ENDPOINT_PROPERTY_QUEUE_DURABLE));
@@ -168,7 +168,7 @@ public class AmqpDeclarer
         }
 
         final String exchangeType = endpointUtil.getEndpointType(endpoint);
-        if (StringUtils.isNotBlank(exchangeType))
+        if (activeDeclarationsOnly && StringUtils.isNotBlank(exchangeType))
         {
             // an exchange type is provided -> the exchange must be declared
             final boolean exchangeDurable = endpointUtil.isExchangeDurable(endpoint);
@@ -199,5 +199,10 @@ public class AmqpDeclarer
     public AmqpEndpointUtil getEndpointUtil()
     {
         return endpointUtil;
+    }
+
+    protected AmqpEndpointUtil createAmqpEndpointUtil ()
+    {
+        return new AmqpEndpointUtil();
     }
 }

--- a/mule-transport-amqp/src/test/java/org/mule/transport/amqp/internal/client/AMQPDeclarationsTestCase.java
+++ b/mule-transport-amqp/src/test/java/org/mule/transport/amqp/internal/client/AMQPDeclarationsTestCase.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  https://github.com/mulesoft/mule-transport-amqp
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.transport.amqp.internal.client;
+
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mule.transport.amqp.internal.connector.AmqpConnector.ENDPOINT_PROPERTY_QUEUE_DURABLE;
+
+import org.mule.api.endpoint.ImmutableEndpoint;
+import org.mule.transport.amqp.internal.endpoint.AmqpEndpointUtil;
+
+import com.rabbitmq.client.Channel;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AMQPDeclarationsTestCase
+{
+    private AmqpEndpointUtil amqpEndpointUtil = mock(AmqpEndpointUtil.class);
+    private final TestAmqpDeclarer amqpDeclarer =  new TestAmqpDeclarer();
+    private final Channel channel = mock(Channel.class, RETURNS_DEEP_STUBS);
+    private final ImmutableEndpoint endpoint = mock(ImmutableEndpoint.class, RETURNS_DEEP_STUBS);
+
+    @Before
+    public void setUp() throws Exception
+    {
+        when(amqpEndpointUtil.getEndpointType(endpoint)).thenReturn("testType");
+        when(amqpEndpointUtil.getQueueName(anyString())).thenReturn("testQueueName");
+        when(endpoint.getProperty(anyString())).thenReturn("");
+        when(endpoint.getProperties().containsKey(ENDPOINT_PROPERTY_QUEUE_DURABLE)).thenReturn(true);
+    }
+
+    @Test
+    public void declareExchangePassively() throws Exception
+    {
+        amqpDeclarer.declareExchange(channel, endpoint, false);
+        verify(channel).exchangeDeclarePassive(anyString());
+        verify(channel, never()).exchangeDeclare(anyString(), anyString(), anyBoolean(), anyBoolean(), anyMap());
+    }
+
+    @Test
+    public void declareExchangeActively() throws Exception
+    {
+        amqpDeclarer.declareExchange(channel, endpoint, true);
+        verify(channel, never()).exchangeDeclarePassive(anyString());
+        verify(channel).exchangeDeclare(anyString(), anyString(), anyBoolean(), anyBoolean(), anyMap());
+    }
+
+    @Test
+    public void declareQueuePassively() throws Exception
+    {
+        amqpDeclarer.declareEndpoint(channel, endpoint, false, "testExchangeName", "testRoutingKey");
+        verify(channel).queueDeclarePassive(anyString());
+        verify(channel, never()).queueDeclare(anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyMap());
+    }
+
+    @Test
+    public void declareQueueActively() throws Exception
+    {
+        amqpDeclarer.declareEndpoint(channel, endpoint, true, "testExchangeName", "testRoutingKey");
+        verify(channel, never()).queueDeclarePassive(anyString());
+        verify(channel).queueDeclare(anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyMap());
+    }
+
+    private class TestAmqpDeclarer extends AmqpDeclarer
+    {
+
+        @Override
+        protected AmqpEndpointUtil createAmqpEndpointUtil()
+        {
+            return amqpEndpointUtil;
+        }
+    }
+}


### PR DESCRIPTION
If an user doesn't want Mule declares queues or exchanges; it should be suffice with not setting activeDeclarationsOnly to true (default value is false).
However when some of some of the exchangeType, queueDurable, queueAutoDelete or queueExclusive attributes are set, the activeDeclarationsOnly is totatly ignored.
Although these scenarios have a WA, it results a bit confusing for customers. 